### PR TITLE
Fix: Translations on multiple pages, removed audio recording, removed family option

### DIFF
--- a/components/SplashScreenComponent.tsx
+++ b/components/SplashScreenComponent.tsx
@@ -59,7 +59,7 @@ const SplashScreenComponent: React.FC<SplashScreenProps> = ({ onFinish }) => {
         <Fade in={textVisible} timeout={1000}>
           <Box sx={{ textAlign: "center" }}>
             <Typography variant="h4" component="h1" fontWeight="bold" color={COLORS.red2}>
-              Sag doch mal, Berlin
+              Sag doch mal, Berlin!
             </Typography>
           </Box>
         </Fade>
@@ -78,7 +78,7 @@ const SplashScreenComponent: React.FC<SplashScreenProps> = ({ onFinish }) => {
         <Fade in={textVisible} timeout={1000}>
           <Box sx={{ textAlign: "center" }}>
             <Typography variant="h6" color={COLORS.green2}>
-              Hören. Reden. Mitgestalten
+              Zuhören. Reden. Mitgestalten
             </Typography>
           </Box>
         </Fade>

--- a/components/StepTracker.tsx
+++ b/components/StepTracker.tsx
@@ -4,6 +4,7 @@ import { Step } from '../types';
 import KeyboardArrowLeft from '@mui/icons-material/KeyboardArrowLeft';
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 import { COLORS } from '../constants';
+import { useLanguage } from "./LanguageContext";
 
 interface StepTrackerProps {
     currentStep: number;
@@ -15,6 +16,7 @@ interface StepTrackerProps {
 const StepTracker: React.FC<StepTrackerProps> = ({ currentStep, steps, onBack, onHelp }) => {
     const theme = useTheme();
     const totalSteps = steps.length - 1; // Welcome step is not counted
+    const { t } = useLanguage();
 
     return (
         <Box>
@@ -59,7 +61,7 @@ const StepTracker: React.FC<StepTrackerProps> = ({ currentStep, steps, onBack, o
                 }
             />
             <Typography variant="body2" align="center" color="text.secondary" sx={{mt: -1}}>
-                Step {currentStep} of {totalSteps}: {steps[currentStep]?.title}
+                {t("dialogue.stepLabel", {current: currentStep, total: totalSteps})}: {steps[currentStep]?.title}
             </Typography>
         </Box>
     );

--- a/components/steps/Step1Core.tsx
+++ b/components/steps/Step1Core.tsx
@@ -89,12 +89,6 @@ const Step1Core: React.FC<AppProps> = ({ data, updateData, onNext }) => {
           }}
         />
 
-        <AudioPaper elevation={0}>
-          <Typography color="text.secondary" fontWeight="500">
-            {t("dialogue.recordAudio")}
-          </Typography>
-          <Chip label={t("common.soon")} disabled />
-        </AudioPaper>
       </Box>
 
       <Footer>

--- a/components/steps/Step2District.tsx
+++ b/components/steps/Step2District.tsx
@@ -88,9 +88,9 @@ const Step2District: React.FC<AppProps> = ({
     <Container>
       <StyledPaper elevation={0}>
         <Typography variant="h4" component="h1" gutterBottom>
-          {t("dialogue.headerTitle")}
+          {t("districts.residenceTitle")}
         </Typography>
-        <Typography variant="h6">{t("dialogue.headerSubtitle")}</Typography>
+        <Typography variant="h6">{t("districts.residenceSubTitle")}</Typography>
       </StyledPaper>
 
       <Grid container spacing={2}>

--- a/components/steps/Step2Topics.tsx
+++ b/components/steps/Step2Topics.tsx
@@ -378,10 +378,10 @@ const Step2Topics: React.FC<AppProps> = ({
         {!isSidebarMode && (
           <StyledPaper elevation={0}>
             <Typography variant="h4" component="h1" gutterBottom>
-              {t("dialogue.headerTitle")}
+              {t("dialogue.categoriesTitle")}
             </Typography>
             <Typography variant="h6">
-              {t("dialogue.headerSubtitle2")}
+              {t("dialogue.categoriesSubtitle")}
             </Typography>
           </StyledPaper>
         )}

--- a/components/steps/Step5Metrics.tsx
+++ b/components/steps/Step5Metrics.tsx
@@ -207,61 +207,6 @@ const Step5Metrics: React.FC<AppProps> = ({
         </Grid>
       </Grid>
 
-      <Paper variant="outlined" sx={{ p: 1, borderRadius: 2 }}>
-        <FormGroup row sx={{ justifyContent: "space-around" }}>
-          <FormControlLabel
-            control={
-              <Checkbox
-                checked={data.participantType === "single"}
-                onChange={() => handleParticipantTypeChange("single")}
-              />
-            }
-            label={t("metrics.single")}
-          />
-          <FormControlLabel
-            control={
-              <Checkbox
-                checked={data.participantType === "family"}
-                onChange={() => handleParticipantTypeChange("family")}
-              />
-            }
-            label={t("metrics.family")}
-          />
-          <FormControlLabel
-            control={
-              <Checkbox
-                checked={data.participantType === "couple"}
-                onChange={() => handleParticipantTypeChange("couple")}
-              />
-            }
-            label={t("metrics.couple")}
-          />
-        </FormGroup>
-      </Paper>
-
-      <Paper
-        variant="outlined"
-        sx={{
-          display: "flex",
-          justifyContent: "space-between",
-          alignItems: "center",
-          p: 2,
-          borderRadius: 2,
-        }}
-      >
-        <Box
-          sx={{
-            display: "flex",
-            alignItems: "center",
-            gap: 1.5,
-            color: "text.secondary",
-          }}
-        >
-          <Typography fontWeight="500">{t("metrics.location")}</Typography>
-        </Box>
-        <Chip label={t("common.soon")} variant="outlined" />
-      </Paper>
-
       <Box
         sx={{
           display: "flex",

--- a/components/steps/Step5Reflection.tsx
+++ b/components/steps/Step5Reflection.tsx
@@ -99,40 +99,6 @@ const Step5Reflection: React.FC<AppProps> = ({
             mb: 3,
           }}
         />
-
-        <Paper
-          variant="outlined"
-          sx={{
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "center",
-            p: 2,
-            borderRadius: 2,
-          }}
-        >
-          <Box
-            sx={{
-              display: "flex",
-              alignItems: "center",
-              gap: 1.5,
-              color: "text.secondary",
-            }}
-          >
-            <MicIcon />
-            <Typography fontWeight="500">
-              {t("reflection.audioRecording")}
-            </Typography>
-          </Box>
-          <Chip label={t("common.soon")} variant="outlined" />
-        </Paper>
-
-        <Typography
-          variant="body2"
-          color="text.secondary"
-          sx={{ mt: 2, fontStyle: "italic" }}
-        >
-          {t("reflection.connectContexts")}
-        </Typography>
       </Box>
 
       <Box

--- a/components/steps/Step6Summary.tsx
+++ b/components/steps/Step6Summary.tsx
@@ -16,7 +16,7 @@ import {
 import { LoadingButton } from "@mui/lab";
 import EditIcon from "@mui/icons-material/Edit";
 import { AppProps, StepId } from "../../types";
-import { INITIATIVES, STEPS } from "../../constants";
+import {INITIATIVES, STEPS, TOPIC_DEFINITIONS} from "../../constants";
 import { saveConversation } from "../../services/conversationService";
 import styled from "styled-components";
 import { COLORS } from "../../constants";
@@ -77,7 +77,7 @@ const SummaryItem: React.FC<SummaryItemProps> = ({
   const { t } = useLanguage();
   const displayValue = value || (
     <Typography component="span" fontStyle="italic" color="text.secondary">
-      Not provided
+        {t("summary.notProvided")}
     </Typography>
   );
 
@@ -156,7 +156,7 @@ const Step6Summary: React.FC<AppProps> = ({
           return (
             <Box key={topicId}>
               <Typography variant="subtitle1" fontWeight="bold">
-                {topicId}
+                  {t(TOPIC_DEFINITIONS.filter(value => value.id === topicId)[0]?.nameKey) || topicId}
               </Typography>
               {details.customNote && (
                 <Typography variant="body2">{details.customNote}</Typography>
@@ -165,15 +165,19 @@ const Step6Summary: React.FC<AppProps> = ({
                 .filter(([key]) => key !== "customNote")
                 .map(([subGroupId, subGroupDetails]: [string, any]) => (
                   <Box key={subGroupId} sx={{ ml: 2, mt: 1 }}>
-                    <Typography variant="subtitle2">{subGroupId}</Typography>
                     {subGroupDetails.selectedOptions?.length > 0 && (
                       <Typography variant="body2">
-                        Selected: {subGroupDetails.selectedOptions.join(", ")}
+                          {(subGroupDetails.selectedOptions || []).map((optionId: string) => {
+                              const topic = TOPIC_DEFINITIONS.find(value => value.id === topicId);
+                              const subGroup = topic?.subGroups?.find((sg: any) => sg.id === subGroupId);
+                              const option = subGroup?.options?.find((opt: any) => opt.id === optionId);
+                              return option ? t(option.nameKey) : optionId;
+                          }).join(", ") || topicId}
                       </Typography>
                     )}
                     {subGroupDetails.customNote && (
                       <Typography variant="body2" color="text.secondary">
-                        Note: {subGroupDetails.customNote}
+                          {t("summary.note")}: {subGroupDetails.customNote}
                       </Typography>
                     )}
                   </Box>
@@ -199,7 +203,7 @@ const Step6Summary: React.FC<AppProps> = ({
             onEdit={() => handleEdit(StepId.District)}
           />
           <SummaryItem
-            label="Topic Details"
+            label={t("dialogue.categoriesTitle")}
             value={renderTopicDetails()}
             editable
             onEdit={() => handleEdit(StepId.Topics)}
@@ -244,10 +248,6 @@ const Step6Summary: React.FC<AppProps> = ({
             value={`${data.numPeople} people, ${data.duration} minutes`}
             editable
             onEdit={() => handleEdit(StepId.Metrics)}
-          />
-          <SummaryItem
-            label={t("metrics.location")}
-            value={data.location || "Not provided"}
           />
         </List>
       </Paper>

--- a/constants.ts
+++ b/constants.ts
@@ -24,17 +24,17 @@ import DevicesIcon from "@mui/icons-material/Devices";
 import { red } from "@mui/material/colors";
 
 export const STEPS: Step[] = [
-  { id: StepId.Welcome, title: "Welcome" },
-  { id: StepId.Core, title: "Core Details" },
-  { id: StepId.District, title: "Select District" },
-  { id: StepId.Topics, title: "Besprochen..." },
-  { id: StepId.Initiatives, title: "Initiatives" },
-  { id: StepId.Consent, title: "Data Consent" },
-  { id: StepId.Reflection, title: "Observer Reflection" },
-  { id: StepId.Metrics, title: "Observer Reflection Metrics" },
+  { id: StepId.Welcome, title: "Willkommen" },
+  { id: StepId.Core, title: "Notizen" },
+  { id: StepId.District, title: "Bezirk auswählen" },
+  { id: StepId.Topics, title: "Kategorien" },
+  { id: StepId.Initiatives, title: "Initiativen" },
+  { id: StepId.Consent, title: "In Kontakt bleiben" },
+  { id: StepId.Reflection, title: "Reflexion" },
+  { id: StepId.Metrics, title: "Gesprächspartner:innen" },
   { id: StepId.reflectionDistrict, title: "Select Reflection Districts" },
-  { id: StepId.Summary, title: "Summary" },
-  { id: StepId.ThankYou, title: "Thank you." },
+  { id: StepId.Summary, title: "Zusammenfassung" },
+  { id: StepId.ThankYou, title: "Danke." },
 ];
 
 export const INITIAL_CONVERSATION_DATA: ConversationData = {

--- a/strings.js
+++ b/strings.js
@@ -4,12 +4,12 @@ export default {
             "stepLabel": "Schritt {{current}} von {{total}}",
             "headerTitle": "Besprochen...",
             "headerSubtitle": "Dokumentiere die Essenz deines Dialogs",
-            "headerSubtitle2": "Wähle alle Themen, die im Dialog\nerwähnt wurden",
+            "categoriesTitle": "Themenauswahl",
+            "categoriesSubtitle": "Wähle alle Themen, die im Dialog\nerwähnt wurden",
             "initiativeMatching": "Selbst aktiv werden",
-            "selectInterests": "Entdecke konkrete Möglichkeiten, etwas zu verändem",
+            "selectInterests": "Entdecke konkrete Möglichkeiten, etwas zu verändern",
             "notesLabel": "Notizen",
             "notesPlaceholder": "Was ist das Interesse des\nDialogpartners\nWas macht für dich eine lebenswerte\nstadt aus?",
-            "recordAudio": "Nimm Audio auf",
             "skip": "überspringen",
             "back": "Zurück",
             "next": "Weiter",
@@ -17,21 +17,23 @@ export default {
             "newDialogue": "Neuer Dialog"
         },
         "welcome": {
-            "title": "Sag doch mal, Berlin",
+            "title": "Sag doch mal, Berlin!",
             "subtitle": "Bürger:innen Dialog zu gesellschaftsrelevanten Themen",
             "startButton": "Starte den Dialog",
             "caredBy": "cared for by Generation iTrust",
-            "tagline": "Hören, Reden, Mitgestalten"
+            "tagline": "Zuhören, Reden, Mitgestalten"
         },
         "login": {
             "welcomeBack": "Willkommen zurück",
             "pleaseSignIn": "Bitte melde dich an, um fortzufahren.",
-            "username": "Username",
-            "password": "Password",
+            "username": "Benutzername",
+            "password": "Passwort",
             "loginButton": "Login"
         },
         "districts": {
-            "selectDistrict": "Bezirk auswählen"
+            "selectDistrict": "Bezirk auswählen",
+            "residenceTitle": "Wohnort",
+            "residenceSubTitle": "Wo wohnt dein:e Gesprächspartner:in?",
         },
         "topics": {
             "housingBuildingTransition": "Bauwende",
@@ -246,8 +248,6 @@ export default {
             "whatElseShowed": "Was hat dir der Dialog noch gezeigt",
             "shareThoughts": "Teile deine Gedanken zu diesem Gespräch – was hat dich überrascht oder was möchtest du dir merken?",
             "resonanceEssence": "Resonanz, Essenz, Takeaway…",
-            "audioRecording": "… oder mach eine Audioaufnahme",
-            "connectContexts": "mit größeren Zusammenhängen zu verknüpfen"
         },
         "metrics": {
             "observerReflectionsMetrics": "Beobachter-Reflexionsmetriken",
@@ -262,7 +262,9 @@ export default {
         },
         "summary": {
             "summary": "Zusammenfassung",
-            "ourQRCode": "Unser QR Code"
+            "ourQRCode": "Unser QR Code",
+            "note": "Notiz",
+            "notProvided": "Keine Angaben"
         },
         "analytics": {
             "analyticsDashboard": "Analyse-Dashboard",
@@ -319,12 +321,12 @@ export default {
             "stepLabel": "Step {{current}} of {{total}}",
             "headerTitle": "Discussed",
             "headerSubtitle": "Document the essence of your dialogue",
-            "headerSubtitle2": "Select all topics that were\nmentioned in the dialogue",
+            "categoriesTitle": "Category selection",
+            "categoriesSubtitle": "Select all topics that were mentioned in the dialogue",
             "initiativeMatching": "Become active yourself",
             "selectInterests": "Discover concrete possibilities to change something",
             "notesLabel": "Notes",
             "notesPlaceholder": "What is the dialogue partner's\ninterest?\nWhat makes a city worth living in\nfor you?",
-            "recordAudio": "Record audio",
             "skip": "Skip",
             "back": "Back",
             "next": "Next",
@@ -332,7 +334,7 @@ export default {
             "newDialogue": "New Dialogue"
         },
         "welcome": {
-            "title": "Yo, speak up, Berlin",
+            "title": "Yo, speak up, Berlin!",
             "subtitle": "Citizens' dialogue on socially relevant topics",
             "startButton": "Start the dialogue",
             "caredBy": "cared for by Generation iTrust",
@@ -346,7 +348,9 @@ export default {
             "loginButton": "Login"
         },
         "districts": {
-            "selectDistrict": "Select District"
+            "selectDistrict": "Select District",
+            "residenceTitle": "Residence",
+            "residenceSubTitle": "Where does your dialogue partner live?",
         },
         "topics": {
             "housingBuildingTransition": "Building Transition",
@@ -561,8 +565,6 @@ export default {
             "whatElseShowed": "What else did the dialogue show you",
             "shareThoughts": "Share your thoughts about this conversation – what surprised you or what would you like to remember?",
             "resonanceEssence": "Resonance, essence, takeaway…",
-            "audioRecording": "… or make an audio recording",
-            "connectContexts": "to connect with larger contexts"
         },
         "metrics": {
             "observerReflectionsMetrics": "Observer Reflections Metrics",
@@ -577,7 +579,9 @@ export default {
         },
         "summary": {
             "summary": "Summary",
-            "ourQRCode": "Our QR Code"
+            "ourQRCode": "Our QR Code",
+            "note": "Note",
+            "notProvided": "Not provided"
         },
         "analytics": {
             "analyticsDashboard": "Analytics Dashboard",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Aligned copy and translations across splash, welcome, and dialogue steps, and localized step/summary labels. Removed audio recording UI and the “family” participant type to match current scope.

- **Bug Fixes**
  - Updated German/English strings for splash title/tagline, login labels, and district/category headers.
  - Localized step titles and the “Step X of Y” label via useLanguage.
  - Localized summary labels (“Not provided”, “Note”) and category title in Step 6.
  - Fixed typos and punctuation in splash and welcome texts.

- **Refactors**
  - Removed audio recording UI from Core and Reflection steps.
  - Dropped “family” participant type and the location placeholder from Metrics; removed location from Summary.
  - Mapped topic and option IDs to translated names in Summary using TOPIC_DEFINITIONS.

<sup>Written for commit 37a65bddea0b693a9945349e8dc95558389e2d3a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

