### PR TITLE
Feature: Authentication - CORS CORS_ORIGIN

### DIFF
--- a/server/src/server.js
+++ b/server/src/server.js
@@ -15,7 +15,7 @@ const app = express();
 app.use(helmet());
 app.use(
     cors({
-        origin: process.env.VITE_API_BASE_URL ? process.env.VITE_API_BASE_URL : '*',
+        origin: process.env.CORS_ORIGIN ? process.env.CORS_ORIGIN : 'https://www.sag-doch-mal.berlin/',
         credentials: true,
     })
 );


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched server CORS to use the CORS_ORIGIN env var and default to https://www.sag-doch-mal.berlin/, replacing VITE_API_BASE_URL and removing the wildcard. This tightens allowed origins for auth requests and cookies.

- **Migration**
  - Set CORS_ORIGIN to your frontend URL for each environment (e.g., http://localhost:3000 in local dev).

<sup>Written for commit a3db9f6cba75c39dcaec37ffaf07ec551f84fd88. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

