### PR TITLE
Feature: Authentication - CORS CORS_ORIGIN

### DIFF
--- a/server/src/server.js
+++ b/server/src/server.js
@@ -15,7 +15,7 @@ const app = express();
 app.use(helmet());
 app.use(
     cors({
-        origin: process.env.CORS_ORIGIN ? process.env.CORS_ORIGIN : 'https://www.sag-doch-mal.berlin/',
+        origin: process.env.CORS_ORIGIN ? process.env.CORS_ORIGIN.split(",") : '*',
         credentials: true,
     })
 );


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable multi-origin CORS by parsing a comma-separated CORS_ORIGIN env variable. Removed the hardcoded default origin and now fall back to '*' when unset.

<sup>Written for commit 5034e117cd21f44e2d37232385babcc4260cc228. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

