### PR TITLE
Feature: Authentication - CORS Localhost fallback

### DIFF
--- a/server/src/server.js
+++ b/server/src/server.js
@@ -15,7 +15,7 @@ const app = express();
 app.use(helmet());
 app.use(
     cors({
-        origin: process.env.CORS_ORIGIN ? process.env.CORS_ORIGIN.split(",") : '*',
+        origin: process.env.CORS_ORIGIN ? process.env.CORS_ORIGIN.split(",") : ['http://localhost:5173'],
         credentials: true,
     })
 );


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set the CORS default origin to http://localhost:5173 when CORS_ORIGIN is not set. This fixes credentialed requests in development and removes the overly permissive "*" fallback.

- **Bug Fixes**
  - Change fallback origin from "*" to ["http://localhost:5173"] to allow cookies and tighten defaults.

- **Migration**
  - If your frontend runs on a different origin, set CORS_ORIGIN to that origin (comma-separated for multiple).

<sup>Written for commit e20ed3b7820a7996c494d766583e14c7dffb73fa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

