### PR TITLE
Feature: Authentication - Prevent login redirect if user is already o…

### DIFF
--- a/components/authentication/axios.tsx
+++ b/components/authentication/axios.tsx
@@ -30,7 +30,7 @@ axiosInstance.interceptors.response.use(
 
         // If the error status is 401 and there is no originalRequest._retry flag,
         // it means the token has expired and we need to refresh it
-        if (error.response.status === 401 && !originalRequest._retry) {
+        if (error.response.status === 401 && !originalRequest._retry && !originalRequest.url.includes("/login")) {
             originalRequest._retry = true;
 
             try {


### PR DESCRIPTION
Feature: Authentication - Prevent login redirect if user is already on login page

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip token refresh/redirect when a 401 occurs on the login route by checking the request URL in the Axios interceptor.
This prevents redirect loops and keeps users on the login page.

<sup>Written for commit 0e31d5e2eb2423ce662b876b8ecfd199f6b3b0fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

