### PR TITLE
Fix: notes in summary, localization of yes and no, token age, login s…

### DIFF
--- a/components/Login.tsx
+++ b/components/Login.tsx
@@ -1,16 +1,16 @@
 import React, { useState } from "react";
 import {
-  Box,
-  Grid,
-  Typography,
-  TextField,
-  Button,
-  IconButton,
-  InputAdornment,
-  Paper,
-  Alert,
-  Collapse,
-  Snackbar,
+    Box,
+    Grid,
+    Typography,
+    TextField,
+    Button,
+    IconButton,
+    InputAdornment,
+    Paper,
+    Alert,
+    Collapse,
+    Snackbar, CircularProgress,
 } from "@mui/material";
 import {
   Person as PersonIcon,
@@ -36,6 +36,7 @@ const Login: React.FC<LoginProps> = ({ onLoginSuccess }) => {
     const [username, setUsername] = useState("");
     const [password, setPassword] = useState("");
     const [showPassword, setShowPassword] = useState(false);
+    const [loading, setLoading] = useState(false);
     const [error, setError] = useState("");
     const [errorToastMessage, setErrorToastMessage] = useState("");
     const [showErrorToast, setShowErrorToast] = useState(false);
@@ -44,6 +45,7 @@ const Login: React.FC<LoginProps> = ({ onLoginSuccess }) => {
     const handleLogin = async (e: React.FormEvent) => {
         e.preventDefault();
         setStoreUsername(username);
+        setLoading(true);
 
         try {
             const response = await axios.post(
@@ -69,6 +71,8 @@ const Login: React.FC<LoginProps> = ({ onLoginSuccess }) => {
             setError(error.response.data.message);
             setErrorToastMessage(t('login.failed'));
             setShowErrorToast(true);
+        } finally {
+            setLoading(false);
         }
     };
 
@@ -309,11 +313,17 @@ const Login: React.FC<LoginProps> = ({ onLoginSuccess }) => {
               fullWidth
               variant="contained"
               color="primary"
-              style={{ backgroundColor: COLORS.green3 }}
+              style={{ backgroundColor: loading ? "#bdbdbd" : COLORS.green3 }}
               sx={{ mt: 3, mb: 2, py: 1.5 }}
+              disabled={loading}
             >
               {t('login.loginButton')}
             </Button>
+              {loading && (
+                  <Box display="flex" justifyContent="center" alignItems="center" sx={{ width: "100%", mt: 2 }}>
+                      <CircularProgress />
+                  </Box>
+              )}
           </Box>
           <Snackbar
             open={showErrorToast}

--- a/components/steps/Step6Summary.tsx
+++ b/components/steps/Step6Summary.tsx
@@ -195,6 +195,12 @@ const Step6Summary: React.FC<AppProps> = ({
       <Paper variant="outlined">
         <List dense>
           <SummaryItem
+              label={t("dialogue.notesLabel")}
+              value={data.notes}
+              editable
+              onEdit={() => handleEdit(StepId.Core)}
+          />
+          <SummaryItem
             label={t("districts.selectDistrict")}
             value={data.districts.join(", ")}
             editable
@@ -219,13 +225,13 @@ const Step6Summary: React.FC<AppProps> = ({
           />
           <SummaryItem
             label={t("consent.stayAnonymous")}
-            value={data.isAnonymous ? "Yes" : "No"}
+            value={data.isAnonymous ? t("consent.yes") : t("consent.no")}
             editable
             onEdit={() => handleEdit(StepId.Consent)}
           />
           <SummaryItem
             label={t("consent.shareContact")}
-            value={data.shareContact ? `Yes (${data.contactInfo})` : "No"}
+            value={data.shareContact ? `${t("consent.yes")} (${data.contactInfo})` : t("consent.no")}
             editable
             onEdit={() => handleEdit(StepId.Consent)}
           />

--- a/server/src/utils/token.js
+++ b/server/src/utils/token.js
@@ -1,6 +1,6 @@
 import jwt from "jsonwebtoken";
 
-const MAX_AGE_REFRESH_TOKEN = 24 * 60 * 60 * 1000;
+const MAX_AGE_REFRESH_TOKEN = 30 * 24 * 60 * 60 * 1000;
 const MAX_AGE_ACCESS_TOKEN = 24 * 60 * 60 * 1000;
 
 const generateAccessToken = (username) => {

--- a/strings.js
+++ b/strings.js
@@ -230,6 +230,8 @@ export default {
             }
         },
         "consent": {
+            "yes": "Ja",
+            "no": "Nein",
             "dataConsent": "Dateneinwilligung",
             "stayInTouch": "In Kontakt bleiben",
             "stayUpToDate": "Bleib auf dem Laufenden – verbinde dich mit Initiativen",
@@ -550,6 +552,8 @@ export default {
             }
         },
         "consent": {
+            "yes": "Yes",
+            "no": "No",
             "dataConsent": "Data Consent",
             "stayInTouch": "Stay In touch",
             "stayUpToDate": "Stay up to date – connect with initiatives",


### PR DESCRIPTION
…pinner

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves UX and localization: adds a loading state to login, shows notes in the final summary, and localizes consent “Yes/No”. Also extends refresh token lifetime to 30 days to reduce re-logins.

- **New Features**
  - Login shows a spinner and disables the button while authenticating.
  - Step 6 summary now includes a “Notes” row.
  - Consent labels use localized “Yes/No”; contact info is shown when sharing is enabled.
  - Refresh token lifespan increased from 1 day to 30 days.

<sup>Written for commit 4a07757dc01c549b7f3f9f67d0773e873f7c1ca1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

