### PR TITLE
Feature: my dialogues

### DIFF
--- a/components/pages/MyDialogues.tsx
+++ b/components/pages/MyDialogues.tsx
@@ -36,10 +36,8 @@ const MyDialogues: React.FC = () => {
         setConversations(response.data);
       } catch (err: any) {
         setError(
-          err?.response?.data?.error ||
-            err?.response?.data?.message ||
-            err?.message ||
-            "Error loading dialogues"
+            err?.response?.data?.error === "No conversations found for this user" ? t("dialogue.noDialogues") :
+                (err?.response?.data?.error || err?.response?.data?.message || err?.message || "Error loading dialogues")
         );
       } finally {
         setLoading(false);

--- a/strings.js
+++ b/strings.js
@@ -16,7 +16,8 @@ export default {
             "continue": "Weiter",
             "dialogueAt": "Gespräch am",
             "newDialogue": "Neuer Dialog",
-            "myDialogues": "Meine Dialoge"
+            "myDialogues": "Meine Dialoge",
+            "noDialogues": "Für den Benutzer wurden keine Gespräche gefunden."
         },
         "welcome": {
             "title": "Sag doch mal, Berlin!",
@@ -340,7 +341,8 @@ export default {
             "continue": "Continue",
             "newDialogue": "New Dialogue",
             "dialogueAt": "Dialogue at",
-            "myDialogues": "My Dialogues"
+            "myDialogues": "My Dialogues",
+            "noDialogues": "No dialogues found for the user."
         },
         "welcome": {
             "title": "Yo, speak up, Berlin!",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Shows a friendly, localized message in My Dialogues when a user has no conversations. Adds EN/DE strings and maps the backend “no conversations” error to this message.

- **New Features**
  - Display t("dialogue.noDialogues") when API returns "No conversations found for this user".
  - Added dialogue.noDialogues translations in English and German.

<sup>Written for commit eba1dc2cbc8c740a08148f06e43907a538b9188d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

