### PR TITLE
Fix: Error localization

### DIFF
--- a/components/pages/MyDialogues.tsx
+++ b/components/pages/MyDialogues.tsx
@@ -36,7 +36,7 @@ const MyDialogues: React.FC = () => {
         setConversations(response.data);
       } catch (err: any) {
         setError(
-            err?.response?.data?.message === "No conversations found for this user" ? t("dialogues.noDialogues") :
+            err?.response?.data?.error === "No conversations found for this user" ? t("dialogue.noDialogues") :
                 (err?.response?.data?.error || err?.response?.data?.message || err?.message || "Error loading dialogues")
         );
       } finally {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes localization of the "No conversations found for this user" error in MyDialogues. We now check response.data.error and use the correct i18n key so users see the translated message.

<sup>Written for commit 2beafc6b55b4aa93e402b2b172006de52d7dca44. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

