### PR TITLE
Improvement: Shortened dashboard label, respect line breaks in strings

### DIFF
--- a/components/pages/MyDialogues.tsx
+++ b/components/pages/MyDialogues.tsx
@@ -46,6 +46,16 @@ const MyDialogues: React.FC = () => {
     fetchConversations();
   }, [username]);
 
+  // Helper function to render multiline text with line breaks
+  const renderMultilineText = (text: string) => {
+    return text.split('\n').map((line, idx) => (
+        <React.Fragment key={idx}>
+          {line}
+          {idx < text.split('\n').length - 1 && <br />}
+        </React.Fragment>
+    ));
+  }
+
 const renderTopicDetails = (conv: ConversationData) => {
   const allEntries: Array<[string, any]> = [];
   Object.entries(conv.topicDetails ?? {}).forEach(([topicId, details]) => {
@@ -79,7 +89,7 @@ const renderTopicDetails = (conv: ConversationData) => {
                   secondary={
                     <>
                       {details.customNote && (
-                          <Typography>{details.customNote}</Typography>
+                          <Typography>{renderMultilineText(details.customNote)}</Typography>
                       )}
                       {Object.entries(details)
                           .filter(([key]) => key !== "customNote")
@@ -97,7 +107,9 @@ const renderTopicDetails = (conv: ConversationData) => {
                                 )}
                                 {subGroupDetails.customNote && (
                                     <Typography variant="body2" color="text.secondary">
-                                      {t("summary.note")}: {subGroupDetails.customNote}
+                                      {t("summary.note")}:
+                                      <br />
+                                      {renderMultilineText(subGroupDetails.customNote)}
                                     </Typography>
                                 )}
                               </Box>
@@ -140,7 +152,7 @@ const renderTopicDetails = (conv: ConversationData) => {
         <Paper>
 
           <List>
-            {conversations.map((conv, idx) => (
+            {conversations.map((conv) => (
                 <React.Fragment key={conv.uuid}>
                   <ListItem divider={true}>
                     <ListItemText
@@ -165,14 +177,18 @@ const renderTopicDetails = (conv: ConversationData) => {
                                 <Box fontWeight="bold">{t("metrics.duration")}:</Box>
                                 <Box>{conv.duration || '-'} {t("metrics.minutes")}</Box>
                               </Grid>
-                              <Grid item xs={12}>
-                                <Box fontWeight="bold">{t("dialogue.notesLabel")}:</Box>
-                                <Box>{conv.notes || '-'}</Box>
-                              </Grid>
-                              <Grid item xs={12}>
-                                <Box fontWeight="bold">{t("reflection.observerReflection")}:</Box>
-                                <Box>{conv.observerReflection || '-'}</Box>
-                              </Grid>
+                              {conv.notes && (
+                                <Grid item xs={12}>
+                                  <Box fontWeight="bold">{t("dialogue.notesLabel")}:</Box>
+                                  <Box>{renderMultilineText(conv.notes)}</Box>
+                                </Grid>
+                              )}
+                              {conv.observerReflection && (
+                                <Grid item xs={12}>
+                                  <Box fontWeight="bold">{t("reflection.observerReflection")}:</Box>
+                                  <Box>{renderMultilineText(conv.observerReflection)}</Box>
+                                </Grid>
+                              )}
                               <Grid item xs={12}>
                                 {renderTopicDetails(conv)}
                               </Grid>

--- a/strings.js
+++ b/strings.js
@@ -277,7 +277,7 @@ export default {
             "notProvided": "Keine Angaben"
         },
         "analytics": {
-            "analyticsDashboard": "Analyse-Dashboard",
+            "analyticsDashboard": "Dashboard",
             "totalDialogues": "Gesamtanzahl Dialoge",
             "totalParticipants": "Gesamtanzahl Teilnehmende",
             "avgDuration": "Durchschn. Dauer (Min.)",
@@ -604,7 +604,7 @@ export default {
             "notProvided": "Not provided",
         },
         "analytics": {
-            "analyticsDashboard": "Analytics Dashboard",
+            "analyticsDashboard": "Dashboard",
             "totalDialogues": "Total Dialogues",
             "totalParticipants": "Total Participants",
             "avgDuration": "Avg. Duration (min)",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Shortened the analytics dashboard label to “Dashboard” (EN/DE). In MyDialogues, multi-line text now displays with line breaks, and empty note sections are hidden.

- **Bug Fixes**
  - Render line breaks for dialogue notes, observer reflections, and custom notes (including subgroup notes); hide fields when empty.

- **Refactors**
  - Use conversation UUID as the list key only.

<sup>Written for commit a454cfa09c7b5b2a24d5118141dc2aa8acc95ea7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

