### PR TITLE
Feature: isAdmin to get all conversations

### DIFF
--- a/server/src/models/User.js
+++ b/server/src/models/User.js
@@ -5,6 +5,7 @@ const UserSchema = new mongoose.Schema(
     {
         username: { type: String, index: true, required: true, unique: true },
         password: { type: String, required: true },
+        isAdmin: { type: Boolean, default: false },
     },
     { timestamps: true }
 );

--- a/server/src/routes/conversations.js
+++ b/server/src/routes/conversations.js
@@ -98,16 +98,21 @@ router.post('/', authenticateAccessToken, async (req, res, next) => {
     }
 });
 
-// Get all conversations for a specific user
+// Get all conversations for a specific user (admins can retrieve all conversations)
 router.get('/user/:username', authenticateAccessToken, async (req, res, next) => {
     try {
         const { username } = req.params;
+        const isAdmin = req.user.isAdmin === true;
 
-        if (req.user.username !== username) {
+        // Non-admin users can only access their own conversations
+        if (!isAdmin && req.user.username !== username) {
             return res.status(403).json({ error: 'Forbidden' });
         }
 
-        const conversations = await Conversation.find({ user: username })
+        // Admins get all conversations; regular users only get their own
+        const filter = isAdmin ? {} : { user: username };
+
+        const conversations = await Conversation.find(filter)
             .select('-piiRef') // Exclude PII-reference
             .sort({ createdAt: -1 })
             .lean();

--- a/server/src/routes/users.js
+++ b/server/src/routes/users.js
@@ -45,7 +45,7 @@ router.post('/login', async (req, res, next) => {
 
             refreshTokens.push(refreshToken);
 
-            return res.json({ username, accessToken });
+            return res.json({ username, isAdmin: user.isAdmin, accessToken });
         } else {
             res.status(401).json({ error: 'Invalid username or password' });
         }
@@ -55,7 +55,7 @@ router.post('/login', async (req, res, next) => {
 });
 
 // Renew access token and refresh token
-router.post("/refresh", (req, res) => {
+router.post("/refresh", async (req, res) => {
     const refreshToken = req.cookies.jwt;
     const { username } = req.body;
 
@@ -63,16 +63,24 @@ router.post("/refresh", (req, res) => {
         return res.status(403).json({ message: "Your token is not correct" });
     }
 
-    jwt.verify(refreshToken, process.env.REFRESH_TOKEN_SECRET, (err) => {
+    jwt.verify(refreshToken, process.env.REFRESH_TOKEN_SECRET, async (err, decoded) => {
         if (err) {
             return res
                 .status(403)
                 .json({ message: "Your session has expired. Please log in again." });
         }
 
-        // Generate new access token
-        const accessToken = generateAccessToken(username);
-        return res.json({ accessToken });
+        // Re-query the database to get the current role, so that privilege
+        // changes (e.g. admin demotion) take effect immediately.
+        const user = await User.findOne({ username: decoded.username }).select('username isAdmin').lean();
+        if (!user) {
+            return res.status(403).json({ message: "User no longer exists." });
+        }
+
+        // Generate new access token (only contains username; isAdmin is
+        // resolved from the DB on every authenticated request)
+        const accessToken = generateAccessToken(user.username);
+        return res.json({ accessToken, isAdmin: user.isAdmin === true });
     });
 });
 

--- a/server/src/utils/token.js
+++ b/server/src/utils/token.js
@@ -1,4 +1,5 @@
 import jwt from "jsonwebtoken";
+import User from "../models/User.js";
 
 const MAX_AGE_REFRESH_TOKEN = 30 * 24 * 60 * 60 * 1000;
 const MAX_AGE_ACCESS_TOKEN = 24 * 60 * 60 * 1000;
@@ -19,7 +20,7 @@ const generateRefreshToken = (username) => {
   );
 }
 
-const authenticateAccessToken = (req, res, next) => {
+const authenticateAccessToken = async (req, res, next) => {
 
     // Grab token from the authorization header
     const authHeader = req.headers['authorization'];
@@ -33,7 +34,16 @@ const authenticateAccessToken = (req, res, next) => {
     }
     try {
         // Verify the token
-        req.user = jwt.verify(token, process.env.ACCESS_TOKEN_SECRET);
+        const decoded = jwt.verify(token, process.env.ACCESS_TOKEN_SECRET);
+
+        // Look up the current role from the database so that privilege
+        // changes (e.g. admin demotion) take effect immediately.
+        const user = await User.findOne({ username: decoded.username }).select('username isAdmin').lean();
+        if (!user) {
+            return res.status(401).json({ message: 'User no longer exists.' });
+        }
+
+        req.user = { username: user.username, isAdmin: user.isAdmin === true };
         next();
     } catch (error) {
         return res.status(401).json({


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds `isAdmin` so admins can list all conversations. Auth now resolves admin status from the DB on each request; non-admins only see their own.

- **New Features**
  - Added `isAdmin` to `User` (default false).
  - Auth: access tokens contain only username; `authenticateAccessToken` loads `isAdmin` from the DB so role changes apply immediately. `/users/login` and `/users/refresh` now include `isAdmin` in the response.
  - `GET /conversations/user/:username` returns all conversations for admins; non-admins get only their own (403 if accessing another user).

- **Migration**
  - Set `isAdmin: true` for admin users to enable global conversation access.

<sup>Written for commit 9fd8fd3d7bc23829b0a41f6b6528eef79a8ae085. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

