### PR TITLE
Feature: Admin-only user creation and listing

### DIFF
--- a/components/AuthenticatedApp.tsx
+++ b/components/AuthenticatedApp.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { Box, Container } from "@mui/material";
 import MainApp from "./MainApp";
 import AnalyticsDashboard from "../analytics/AnalyticsDashboard";
@@ -6,13 +6,16 @@ import BottomNavigationBar from "./ui/BottomNavigationBar";
 import { useStepNavigation } from "../hooks/hooks";
 import { StepId, STEPS } from "../constants";
 import MyDialogues from "./pages/MyDialogues.tsx";
+import AdminUsers from "./pages/AdminUsers.tsx";
+import { AppView, useViewStore } from "./viewStore.tsx";
 
 const AuthenticatedApp: React.FC = () => {
-  const [view, setView] = useState<"dialogue" | "dashboard" | "myDialogues">("dialogue");
+  const view = useViewStore((state) => state.view);
+  const setView = useViewStore((state) => state.setView);
   const { restart, currentStep } = useStepNavigation();
 
-  const handleViewChange = (newView: "dialogue" | "dashboard" | "myDialogues") => {
-    if (newView === "dialogue" && view === "dashboard" || newView === "dialogue" && view === "myDialogues") {
+  const handleViewChange = (newView: AppView) => {
+    if (newView === "dialogue" && (view === "dashboard" || view === "myDialogues")) {
       // When switching from dashboard to start a new dialogue, reset the survey state
       restart();
     }
@@ -30,6 +33,7 @@ const AuthenticatedApp: React.FC = () => {
         {view === "dialogue" && <MainApp />}
         {view === "dashboard" && <AnalyticsDashboard />}
         {view === "myDialogues" && <MyDialogues />}
+        {view === "adminUsers" && <AdminUsers onBack={() => handleViewChange("dialogue")} />}
       </Container>
       {shouldShowBottomNavigationBar && (
         <BottomNavigationBar

--- a/components/Login.tsx
+++ b/components/Login.tsx
@@ -33,6 +33,7 @@ const Login: React.FC<LoginProps> = ({ onLoginSuccess }) => {
 
     const setAccessToken = useAuthStore((state) => state.setAccessToken);
     const setStoreUsername = useAuthStore((state) => state.setUsername);
+    const setIsAdmin = useAuthStore((state) => state.setIsAdmin);
     const [username, setUsername] = useState("");
     const [password, setPassword] = useState("");
     const [showPassword, setShowPassword] = useState(false);
@@ -60,8 +61,9 @@ const Login: React.FC<LoginProps> = ({ onLoginSuccess }) => {
             );
 
             if (response.status === 200) {
-                const { accessToken } = response.data;
+                const { accessToken, isAdmin } = response.data;
                 setAccessToken(accessToken);
+                setIsAdmin(!!isAdmin);
                 onLoginSuccess();
             } else {
                 const errorData = await response.data;

--- a/components/authentication/authStore.tsx
+++ b/components/authentication/authStore.tsx
@@ -3,15 +3,19 @@ import { create } from 'zustand';
 interface AuthState {
     username: string;
     accessToken: string | null;
+    isAdmin: boolean;
     setUsername: (username: string | null) => void;
     setAccessToken: (token: string | null) => void;
+    setIsAdmin: (isAdmin: boolean) => void;
     clearTokens: () => void;
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
     username: null,
     accessToken: null,
+    isAdmin: false,
     setUsername: (username) => set({ username }),
     setAccessToken: (token) => set({ accessToken: token }),
-    clearTokens: () => set({ accessToken: null }),
+    setIsAdmin: (isAdmin) => set({ isAdmin }),
+    clearTokens: () => set({ accessToken: null, isAdmin: false }),
 }));

--- a/components/authentication/axios.tsx
+++ b/components/authentication/axios.tsx
@@ -40,6 +40,7 @@ axiosInstance.interceptors.response.use(
                     { withCredentials: true }
                 );
                 useAuthStore.getState().setAccessToken(data.accessToken);
+                useAuthStore.getState().setIsAdmin(!!data.isAdmin);
                 axios.defaults.headers.common["Authorization"] = `Bearer ${data.accessToken}`;
 
                 return axiosInstance(originalRequest);

--- a/components/pages/AdminUsers.tsx
+++ b/components/pages/AdminUsers.tsx
@@ -1,0 +1,234 @@
+import React, { useEffect, useState } from "react";
+import {
+  Box,
+  Typography,
+  TextField,
+  Button,
+  IconButton,
+  InputAdornment,
+  Paper,
+  Alert,
+  Collapse,
+  Snackbar,
+  CircularProgress,
+  FormControlLabel,
+  Checkbox,
+  List,
+  ListItem,
+  ListItemText,
+  Chip,
+} from "@mui/material";
+import {
+  Person as PersonIcon,
+  Lock as LockIcon,
+  Visibility,
+  VisibilityOff,
+  ArrowBack as ArrowBackIcon,
+} from "@mui/icons-material";
+import axios from "../authentication/axios";
+import { useLanguage } from "../LanguageContext";
+
+interface AdminUsersProps {
+  onBack: () => void;
+}
+
+interface UserEntry {
+  _id: string;
+  username: string;
+  isAdmin: boolean;
+  createdAt?: string;
+}
+
+const AdminUsers: React.FC<AdminUsersProps> = ({ onBack }) => {
+  const { t } = useLanguage();
+
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  const [users, setUsers] = useState<UserEntry[]>([]);
+  const [listLoading, setListLoading] = useState(true);
+  const [listError, setListError] = useState("");
+
+  const [toastOpen, setToastOpen] = useState(false);
+  const [toastMessage, setToastMessage] = useState("");
+
+  const fetchUsers = async () => {
+    setListLoading(true);
+    setListError("");
+    try {
+      const response = await axios.get("/users");
+      setUsers(response.data);
+    } catch (err: any) {
+      setListError(
+        err?.response?.data?.error ||
+          err?.response?.data?.message ||
+          err?.message ||
+          t("admin.loadError")
+      );
+    } finally {
+      setListLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchUsers();
+  }, []);
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setError("");
+
+    try {
+      await axios.post("/users", { username, password, isAdmin });
+      setToastMessage(t("admin.createSuccess"));
+      setToastOpen(true);
+      setUsername("");
+      setPassword("");
+      setIsAdmin(false);
+      await fetchUsers();
+    } catch (err: any) {
+      setError(
+        err?.response?.data?.error ||
+          err?.response?.data?.message ||
+          err?.message ||
+          t("admin.createError")
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Box sx={{ maxWidth: 600, mx: "auto", mt: 4 }}>
+      <Box sx={{ display: "flex", alignItems: "center", mb: 2 }}>
+        <IconButton onClick={onBack} aria-label={t("admin.back")} sx={{ mr: 1 }}>
+          <ArrowBackIcon />
+        </IconButton>
+        <Typography variant="h4">{t("admin.title")}</Typography>
+      </Box>
+
+      {/* Create user form */}
+      <Paper elevation={3} sx={{ p: 3, mb: 4 }}>
+        <Typography variant="h6" sx={{ mb: 2 }}>
+          {t("admin.createUser")}
+        </Typography>
+        <Box component="form" noValidate onSubmit={handleCreate}>
+          <Collapse in={!!error}>
+            <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError("")}>
+              {error}
+            </Alert>
+          </Collapse>
+          <TextField
+            margin="normal"
+            required
+            fullWidth
+            label={t("admin.username")}
+            variant="filled"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <PersonIcon color="action" />
+                </InputAdornment>
+              ),
+            }}
+          />
+          <TextField
+            margin="normal"
+            required
+            fullWidth
+            label={t("admin.password")}
+            type={showPassword ? "text" : "password"}
+            variant="filled"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            helperText={t("admin.passwordHint")}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <LockIcon color="action" />
+                </InputAdornment>
+              ),
+              endAdornment: (
+                <InputAdornment position="end">
+                  <IconButton
+                    aria-label="toggle password visibility"
+                    onClick={() => setShowPassword(!showPassword)}
+                    onMouseDown={(e) => e.preventDefault()}
+                    edge="end"
+                  >
+                    {showPassword ? <VisibilityOff /> : <Visibility />}
+                  </IconButton>
+                </InputAdornment>
+              ),
+            }}
+          />
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={isAdmin}
+                onChange={(e) => setIsAdmin(e.target.checked)}
+              />
+            }
+            label={t("admin.isAdmin")}
+          />
+          <Button
+            type="submit"
+            fullWidth
+            variant="contained"
+            sx={{ mt: 2, py: 1.5 }}
+            disabled={submitting}
+          >
+            {t("admin.createButton")}
+          </Button>
+          {submitting && (
+            <Box display="flex" justifyContent="center" sx={{ width: "100%", mt: 2 }}>
+              <CircularProgress />
+            </Box>
+          )}
+        </Box>
+      </Paper>
+
+      {/* User list */}
+      <Typography variant="h6" sx={{ mb: 1 }}>
+        {t("admin.existingUsers")} ({users.length})
+      </Typography>
+      {listLoading ? (
+        <Box sx={{ display: "flex", justifyContent: "center", mt: 4 }}>
+          <CircularProgress />
+        </Box>
+      ) : listError ? (
+        <Alert severity="error">{listError}</Alert>
+      ) : (
+        <Paper>
+          <List>
+            {users.map((user) => (
+              <ListItem key={user._id} divider>
+                <ListItemText primary={user.username} />
+                {user.isAdmin && (
+                  <Chip label={t("admin.adminBadge")} color="primary" size="small" />
+                )}
+              </ListItem>
+            ))}
+          </List>
+        </Paper>
+      )}
+
+      <Snackbar
+        open={toastOpen}
+        autoHideDuration={4000}
+        onClose={() => setToastOpen(false)}
+        anchorOrigin={{ vertical: "top", horizontal: "center" }}
+        message={toastMessage}
+      />
+    </Box>
+  );
+};
+
+export default AdminUsers;

--- a/components/ui/AppMenu.tsx
+++ b/components/ui/AppMenu.tsx
@@ -6,10 +6,15 @@ import React, { useState } from "react";
 import LanguageToggle from "./LanguageToggle.tsx";
 import axios from "../authentication/axios.tsx";
 import { useAuthStore } from "../authentication/authStore.tsx";
+import { useViewStore } from "../viewStore.tsx";
+import { useLanguage } from "../LanguageContext";
 
 const AppMenu: React.FC = () => {
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
     const open = Boolean(anchorEl);
+    const isAdmin = useAuthStore((state) => state.isAdmin);
+    const setView = useViewStore((state) => state.setView);
+    const { t } = useLanguage();
 
     const handleMenuClick = (event: React.MouseEvent<HTMLElement>) => {
         setAnchorEl(event.currentTarget);
@@ -61,6 +66,12 @@ const AppMenu: React.FC = () => {
                 <MenuItem>
                     <LanguageToggle />
                 </MenuItem>
+                {isAdmin && (
+                    <MenuItem
+                        onClick={() => { setView("adminUsers"); handleMenuClose(); }}>
+                        {t('admin.manageUsers')}
+                    </MenuItem>
+                )}
                 <MenuItem
                     onClick={() => { handleLogout(); handleMenuClose();}}>
                     Logout

--- a/components/ui/BottomNavigationBar.tsx
+++ b/components/ui/BottomNavigationBar.tsx
@@ -2,14 +2,15 @@ import * as React from "react";
 import { BottomNavigation, BottomNavigationAction, Paper } from "@mui/material";
 import { COLORS } from "../../constants";
 import { useLanguage } from "../LanguageContext";
+import { AppView } from "../viewStore.tsx";
 
 let editNotes = "/icons/note_in_folder_icon.png";
 let piechartIcon = "/icons/pie_chart_icon.png";
 let listIcon = "/icons/list.png";
 
 interface BottomNavigationBarProps {
-  currentView: "dialogue" | "dashboard" | "myDialogues";
-  onTabChange: (view: "dialogue" | "dashboard" | "myDialogues") => void;
+  currentView: AppView;
+  onTabChange: (view: AppView) => void;
 }
 
 const BottomNavigationBar: React.FC<BottomNavigationBarProps> = ({
@@ -19,7 +20,7 @@ const BottomNavigationBar: React.FC<BottomNavigationBarProps> = ({
   const { t } = useLanguage();
   const handleChange = (
     event: React.SyntheticEvent,
-    newValue: "dialogue" | "dashboard" | "myDialogues"
+    newValue: AppView
   ) => {
     onTabChange(newValue);
   };

--- a/components/viewStore.tsx
+++ b/components/viewStore.tsx
@@ -1,0 +1,16 @@
+import { create } from 'zustand';
+
+// The top-level views rendered by AuthenticatedApp. Kept in a shared store so
+// siblings such as AppMenu (which lives outside AuthenticatedApp in App.tsx)
+// can switch the active view.
+export type AppView = "dialogue" | "dashboard" | "myDialogues" | "adminUsers";
+
+interface ViewState {
+    view: AppView;
+    setView: (view: AppView) => void;
+}
+
+export const useViewStore = create<ViewState>((set) => ({
+    view: "dialogue",
+    setView: (view) => set({ view }),
+}));

--- a/server/src/models/User.js
+++ b/server/src/models/User.js
@@ -12,8 +12,7 @@ const UserSchema = new mongoose.Schema(
 
 UserSchema.pre('save', async function (next) {
     if (!this.isModified('password')) {
-        console.log("next");
-        next();
+        return next();
     }
     const salt = await bcrypt.genSalt(10);
     this.password = await bcrypt.hash(this.password, salt);

--- a/server/src/routes/users.js
+++ b/server/src/routes/users.js
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import Joi from 'joi';
 import User from '../models/User.js';
 import jwt from "jsonwebtoken";
-import {generateAccessToken, generateRefreshToken, MAX_AGE_REFRESH_TOKEN} from "../utils/token.js";
+import {generateAccessToken, generateRefreshToken, authenticateAccessToken, requireAdmin, MAX_AGE_REFRESH_TOKEN} from "../utils/token.js";
 
 const router = Router();
 
@@ -10,6 +10,13 @@ const router = Router();
 const userSchema = Joi.object({
     username: Joi.string().required(),
     password: Joi.string().required(),
+});
+
+// Admins may create users with an optional admin flag and a minimum password length.
+const createUserSchema = Joi.object({
+    username: Joi.string().required(),
+    password: Joi.string().min(8).required(),
+    isAdmin: Joi.boolean().default(false),
 });
 
 let refreshTokens = [];
@@ -91,6 +98,39 @@ router.post('/logout', (req, res) => {
         res.clearCookie('jwt', { path: '/api/v1' });
     }
     res.status(200).json({ message: 'Logout successful' });
+});
+
+// Admin: create a new user
+router.post('/', authenticateAccessToken, requireAdmin, async (req, res, next) => {
+    try {
+        const { value, error } = createUserSchema.validate(req.body, { stripUnknown: true });
+        if (error) {
+            return res.status(400).json({ error: error.message });
+        }
+
+        const { username, password, isAdmin } = value;
+
+        const userExists = await User.findOne({ username });
+        if (userExists) {
+            return res.status(409).json({ error: 'User already exists' });
+        }
+
+        // The pre('save') hook hashes the password, so do not hash it here.
+        const user = await User.create({ username, password, isAdmin });
+        return res.status(201).json({ username: user.username, isAdmin: user.isAdmin });
+    } catch (e) {
+        next(e);
+    }
+});
+
+// Admin: list all users (never expose password hashes)
+router.get('/', authenticateAccessToken, requireAdmin, async (req, res, next) => {
+    try {
+        const users = await User.find({}, 'username isAdmin createdAt').sort({ username: 1 });
+        return res.json(users);
+    } catch (e) {
+        next(e);
+    }
 });
 
 export default router;

--- a/server/src/utils/token.js
+++ b/server/src/utils/token.js
@@ -52,4 +52,13 @@ const authenticateAccessToken = async (req, res, next) => {
     }
 };
 
-export { generateAccessToken, generateRefreshToken, authenticateAccessToken, MAX_AGE_REFRESH_TOKEN };
+// Requires an authenticated admin. Must run after authenticateAccessToken,
+// which resolves req.user.isAdmin from the database.
+const requireAdmin = (req, res, next) => {
+    if (!req.user || req.user.isAdmin !== true) {
+        return res.status(403).json({ message: 'Forbidden - admin access required' });
+    }
+    next();
+};
+
+export { generateAccessToken, generateRefreshToken, authenticateAccessToken, requireAdmin, MAX_AGE_REFRESH_TOKEN };

--- a/strings.js
+++ b/strings.js
@@ -34,6 +34,22 @@ export default {
             "loginButton": "Login",
             "failed": "Benutzername oder Passwort ungültig"
         },
+        "admin": {
+            "manageUsers": "Benutzer verwalten",
+            "title": "Benutzerverwaltung",
+            "back": "Zurück",
+            "createUser": "Neuen Benutzer anlegen",
+            "username": "Benutzername",
+            "password": "Passwort",
+            "passwordHint": "Mindestens 8 Zeichen",
+            "isAdmin": "Administrator",
+            "adminBadge": "Admin",
+            "createButton": "Benutzer anlegen",
+            "createSuccess": "Benutzer erfolgreich angelegt",
+            "createError": "Benutzer konnte nicht angelegt werden",
+            "existingUsers": "Vorhandene Benutzer",
+            "loadError": "Benutzer konnten nicht geladen werden"
+        },
         "districts": {
             "district": "Bezirk",
             "selectDistrict": "Bezirk auswählen",
@@ -361,6 +377,22 @@ export default {
             "password": "Password",
             "loginButton": "Login",
             "failed": "Invalid username or password"
+        },
+        "admin": {
+            "manageUsers": "Manage users",
+            "title": "User management",
+            "back": "Back",
+            "createUser": "Create new user",
+            "username": "Username",
+            "password": "Password",
+            "passwordHint": "At least 8 characters",
+            "isAdmin": "Administrator",
+            "adminBadge": "Admin",
+            "createButton": "Create user",
+            "createSuccess": "User created successfully",
+            "createError": "User could not be created",
+            "existingUsers": "Existing users",
+            "loadError": "Could not load users"
         },
         "districts": {
             "district": "District",


### PR DESCRIPTION
Add an admin-gated way to create users and view existing users.

Backend:
- Add requireAdmin middleware (reuses req.user.isAdmin resolved by authenticateAccessToken) and protect two new endpoints with it.
- Add POST /api/v1/users (create; min-8 password; optional isAdmin; 409 on duplicate) and GET /api/v1/users (list without password hashes).
- Fix User pre('save') hook missing return that double-hashed passwords on subsequent saves.

Frontend:
- Add isAdmin to the auth store, populated on login and token refresh.
- Add a shared view store so AppMenu can switch to the admin view.
- Add AdminUsers page (create form + user list) reachable via an admin-only Manage users item in AppMenu.
- Add de/en translations for the admin panel.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add admin-only user management: create users and list users, plus a new Admin Users page in the app. Protects new endpoints with admin checks and wires `isAdmin` through auth and navigation.

- **New Features**
  - Backend: add admin-only `POST /api/v1/users` (min-8 password, optional `isAdmin`, 409 on duplicate) and `GET /api/v1/users` (no password hashes) via `requireAdmin` after `authenticateAccessToken`.
  - Frontend: store `isAdmin` in the auth store from login and token refresh; add `viewStore` for cross-component view switching.
  - UI: new `AdminUsers` page (create user + list) accessible via an admin-only “Manage users” menu; add de/en translations.

- **Bug Fixes**
  - Stop double-hashing passwords on subsequent saves in the `User` model’s pre('save') hook.

<sup>Written for commit c694d78f5f23013e4e5c585e986f1c3026f7e7db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cyberconical/Klimaneustart_iTrust_V1/pull/30?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

