### PR TITLE
Feature: CSV export and admin conversation scope toggle

### DIFF
--- a/components/pages/MyDialogues.tsx
+++ b/components/pages/MyDialogues.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import QuestionAnswerIcon from '@mui/icons-material/QuestionAnswer';
+import DownloadIcon from '@mui/icons-material/Download';
 import {
   Box,
   Typography,
@@ -9,6 +10,9 @@ import {
   Paper,
   CircularProgress,
   Alert, Grid, ListItemAvatar, Avatar,
+  Switch,
+  FormControlLabel,
+  Button,
 } from "@mui/material";
 import { useAuthStore } from "../authentication/authStore.tsx";
 import axios from "../authentication/axios";
@@ -18,11 +22,14 @@ import {TOPIC_DEFINITIONS} from "../../constants.ts";
 
 const MyDialogues: React.FC = () => {
   const username = useAuthStore((state) => state.username);
+  const isAdmin = useAuthStore((state) => state.isAdmin);
   const { t } = useLanguage();
   const language = useLanguage().language;
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [exportError, setExportError] = useState<string | null>(null);
   const [conversations, setConversations] = useState<ConversationData[]>([]);
+  const [onlyMine, setOnlyMine] = useState(false);
 
   useEffect(() => {
     const fetchConversations = async () => {
@@ -31,8 +38,11 @@ const MyDialogues: React.FC = () => {
         setLoading(false);
         return;
       }
+      setLoading(true);
       try {
-        const response = await axios.get(`/conversations/user/${username}`);
+        const response = await axios.get(
+            `/conversations/user/${username}${isAdmin ? `?all=${!onlyMine}` : ''}`
+        );
         setConversations(response.data);
       } catch (err: any) {
         setError(
@@ -44,7 +54,25 @@ const MyDialogues: React.FC = () => {
       }
     };
     fetchConversations();
-  }, [username]);
+  }, [username, isAdmin, onlyMine]);
+
+  const handleExportCsv = async () => {
+    setExportError(null);
+    try {
+      const response = await axios.get('/conversations/export/csv', {
+        params: isAdmin ? { all: !onlyMine } : undefined,
+        responseType: 'blob',
+      });
+      const url = URL.createObjectURL(response.data);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = 'conversations-export.csv';
+      link.click();
+      URL.revokeObjectURL(url);
+    } catch (err: any) {
+      setExportError(err?.response?.data?.error || err?.message || t("dialogue.exportFailed"));
+    }
+  };
 
   // Helper function to render multiline text with line breaks
   const renderMultilineText = (text: string) => {
@@ -141,9 +169,27 @@ const renderTopicDetails = (conv: ConversationData) => {
 
   return (
     <Box sx={{ maxWidth: 600, mx: "auto", mt: 4 }}>
-      <Typography variant="h4" gutterBottom>
-        {t("dialogue.myDialogues")} ({conversations.length})
-      </Typography>
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", flexWrap: "wrap", gap: 1 }}>
+        <Typography variant="h4" gutterBottom>
+          {t("dialogue.myDialogues")} ({conversations.length})
+        </Typography>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
+          {isAdmin && (
+            <FormControlLabel
+                control={<Switch checked={onlyMine} onChange={(e) => setOnlyMine(e.target.checked)} />}
+                label={t("dialogue.onlyMyDialogues")}
+            />
+          )}
+          <Button variant="outlined" startIcon={<DownloadIcon />} onClick={handleExportCsv}>
+            {t("dialogue.exportCsv")}
+          </Button>
+        </Box>
+      </Box>
+      {exportError && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setExportError(null)}>
+          {exportError}
+        </Alert>
+      )}
       {conversations.length === 0 ? (
         <Typography color="text.secondary">
           {t("dialogue.noDialoguesFound") || "Keine Dialoge gefunden."}

--- a/server/src/routes/conversations.js
+++ b/server/src/routes/conversations.js
@@ -3,6 +3,7 @@ import Joi from 'joi';
 import Conversation from '../models/Conversation.js';
 import { authenticateAccessToken } from "../utils/token.js";
 import {getAnalyticsData} from "../controllers/analytics.js";
+import { toCsv } from "../utils/csv.js";
 
 const router = Router();
 
@@ -65,8 +66,10 @@ router.get('/user/:username', authenticateAccessToken, async (req, res, next) =>
             return res.status(403).json({ error: 'Forbidden' });
         }
 
-        // Admins get all conversations; regular users only get their own
-        const filter = isAdmin ? {} : { user: username };
+        // Admins can explicitly request everyone's conversations via ?all=true;
+        // otherwise (and for non-admins always) only the requested user's own.
+        const showAll = isAdmin && req.query.all === 'true';
+        const filter = showAll ? {} : { user: username };
 
         const conversations = await Conversation.find(filter)
             .sort({ createdAt: -1 })
@@ -82,6 +85,27 @@ router.get('/user/:username', authenticateAccessToken, async (req, res, next) =>
     }
 });
 
+// Export conversations as CSV with every stored field. Non-admins always get
+// only their own conversations; admins can pass ?all=true for everyone's.
+router.get('/export/csv', authenticateAccessToken, async (req, res, next) => {
+    try {
+        const isAdmin = req.user.isAdmin === true;
+        const showAll = isAdmin && req.query.all === 'true';
+        const filter = showAll ? {} : { user: req.user.username };
+
+        const conversations = await Conversation.find(filter)
+            .sort({ createdAt: -1 })
+            .lean();
+
+        const csv = toCsv(conversations);
+
+        res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+        res.setHeader('Content-Disposition', 'attachment; filename="conversations-export.csv"');
+        res.send('﻿' + csv);
+    } catch (e) {
+        next(e);
+    }
+});
 
 // Get conversation content (without PII)
 router.get('/:id', authenticateAccessToken, async (req, res, next) => {

--- a/server/src/utils/csv.js
+++ b/server/src/utils/csv.js
@@ -1,0 +1,49 @@
+// Full column list mirrors the Conversation schema plus Mongoose-added metadata,
+// so the export always contains every stored field, not just what the UI renders.
+const COLUMNS = [
+    '_id',
+    'uuid',
+    'status',
+    'user',
+    'notes',
+    'mainInterest',
+    'livableCity',
+    'topicDetails',
+    'districts',
+    'selectedInitiatives',
+    'interestAreas',
+    'observerReflection',
+    'surprise',
+    'numPeople',
+    'duration',
+    'location',
+    'createdAt',
+    'updatedAt',
+    '__v',
+];
+
+const formatCell = (value) => {
+    if (value === undefined || value === null) return '';
+    if (value instanceof Date) return value.toISOString();
+    if (Array.isArray(value)) return value.join('; ');
+    if (typeof value === 'object') return JSON.stringify(value);
+    return String(value);
+};
+
+const escapeCell = (value) => {
+    const str = formatCell(value);
+    if (/["\n,]/.test(str)) {
+        return `"${str.replace(/"/g, '""')}"`;
+    }
+    return str;
+};
+
+const toCsv = (rows) => {
+    const lines = [COLUMNS.join(',')];
+    for (const row of rows) {
+        lines.push(COLUMNS.map((col) => escapeCell(row[col])).join(','));
+    }
+    return lines.join('\n');
+};
+
+export { toCsv };

--- a/strings.js
+++ b/strings.js
@@ -17,7 +17,10 @@ export default {
             "dialogueAt": "Gespräch am",
             "newDialogue": "Neuer Dialog",
             "myDialogues": "Meine Dialoge",
-            "noDialogues": "Für den Benutzer wurden keine Gespräche gefunden."
+            "noDialogues": "Für den Benutzer wurden keine Gespräche gefunden.",
+            "onlyMyDialogues": "Nur meine Dialoge",
+            "exportCsv": "Als CSV exportieren",
+            "exportFailed": "CSV-Export fehlgeschlagen."
         },
         "welcome": {
             "title": "Sag doch mal, Berlin!",
@@ -345,7 +348,10 @@ export default {
             "newDialogue": "New Dialogue",
             "dialogueAt": "Dialogue at",
             "myDialogues": "My Dialogues",
-            "noDialogues": "No dialogues found for the user."
+            "noDialogues": "No dialogues found for the user.",
+            "onlyMyDialogues": "Only my dialogues",
+            "exportCsv": "Export as CSV",
+            "exportFailed": "CSV export failed."
         },
         "welcome": {
             "title": "Yo, speak up, Berlin!",


### PR DESCRIPTION
Adds a CSV export button on My Dialogues that dumps full MongoDB conversation fields (not just what the UI displays); every user can export their own conversations, admins can export everyone's. Also adds an admin-only "Nur meine Dialoge" switch to explicitly choose between seeing all conversations or only their own, replacing the previous implicit admin-always-sees-everything behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add CSV export for conversations and an explicit admin scope toggle on My Dialogues. Users can export their own data; admins can switch between only theirs or all and export accordingly.

- New Features
  - UI and behavior: Added "Export as CSV" button on My Dialogues and an admin-only "Only my dialogues" switch to choose own vs all conversations (replaces implicit admin sees everything).
  - API: `GET /conversations/user/:username` now supports `?all=true` for admins; `GET /conversations/export/csv` returns CSV and accepts `?all=true` for admins. Non-admins always get only their own.
  - CSV format: Exports all stored fields with a fixed column order; arrays joined by `;`, objects JSON-stringified, dates in ISO 8601, proper CSV escaping, and UTF-8 BOM for spreadsheet compatibility.

<sup>Written for commit f57b9d44a58fbdceb7b72d22aebe21f65f1ce23d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cyberconical/Klimaneustart_iTrust_V1/pull/32?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

